### PR TITLE
change data type from both tables to big int

### DIFF
--- a/storage/db/migrations/20221027145230_big_integer_user_interactions.php
+++ b/storage/db/migrations/20221027145230_big_integer_user_interactions.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class BigIntegerUserInteractions extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change() : void
+    {
+        $this->table('users_interactions')
+            ->changeColumn('entity_id', 'biginteger', ['null' => true])
+            ->save();
+    }
+}

--- a/storage/db/migrations/20221027145231_big_integer_user_messages.php
+++ b/storage/db/migrations/20221027145231_big_integer_user_messages.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class BigIntegerUserMessages extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change(): void
+    {
+        $this->table('user_messages')
+            ->changeColumn('id', 'biginteger', ['null' => true])
+            ->save();
+    }
+}


### PR DESCRIPTION
Features and Changes:

- Change `id` column data type from int to big int on `user_messages`.
- Change `entity_id` column data type from char to big int on `user_interactions`.